### PR TITLE
Set target attribute to "_blank" on facebook link

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
   <h1> This is the beginning of Study Group | The Odin Project collaborative project </h1>
   <h2>Here is the link to the facebook page if you want to join the fun</h2>
-  <a href="https://www.facebook.com/groups/TOPSTUDYGROUP/">THE FACEBOOK STUDY GROUP</a>
+  <a href="https://www.facebook.com/groups/TOPSTUDYGROUP/" target="_blank">THE FACEBOOK STUDY GROUP</a>
   <h2> Project Contributors </h2>
   <!-- feel free to add your name to the list of contributors! You can do this by adding a <li>name</li> under the previous name.-->
   <div id="contributors">


### PR DESCRIPTION
On line 14 set the target attribute to "_blank" for open the link in a new browser window or a new tab
